### PR TITLE
remove HewlettPackard from gopath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docker-machine*
 .idea/
 ./bin
 cover
+Godeps/_workspace/src/github.com/HewlettPackard/


### PR DESCRIPTION
Signed-off-by: Edward Raigosa <edward.raigosa@hpe.com>