### PR TITLE
Fix #72 golang 1.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.5.1
+- 1.6
 install:
 - go get github.com/mattn/goveralls
 - go get -u github.com/golang/lint/golint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.6
+
+RUN go get  github.com/golang/lint/golint \
+            github.com/mattn/goveralls \
+            golang.org/x/tools/cover \
+            github.com/tools/godep \
+            github.com/aktau/github-release
+
+ENV USER root
+WORKDIR /go/src/github.com/HewlettPackard/docker-machine-oneview
+
+COPY . /go/src/github.com/HewlettPackard/docker-machine-oneview

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ else
 DOCKER_IMAGE_NAME := "docker-machine-build"
 DOCKER_CONTAINER_NAME := docker-machine-build-container
 # get the dockerfile from docker/machine project so we stay in sync with the versions they use for go
-DOCKER_FILE_URL := "https://raw.githubusercontent.com/docker/machine/master/Dockerfile"
+# TODO: delete DOCKER_FILE_URL := "https://raw.githubusercontent.com/docker/machine/master/Dockerfile"
+DOCKER_FILE_URL := file://$(PREFIX)/Dockerfile
 DOCKER_FILE := .dockerfile.machine
 
 noop:


### PR DESCRIPTION
We also updated to add a dockerfile so that
we can't build a little more independent from upstream
godep in particular is missing for us

Signed-off-by: Edward Raigosa <edward.raigosa@hpe.com>