### PR TITLE
support multiple build plans per sdk PR #73

### DIFF
--- a/docs/oneview.md
+++ b/docs/oneview.md
@@ -126,7 +126,7 @@ Environment variables and default values:
 | `--oneview-ssh-port`       | OneView build plan ssh host port
 |                            |
 | `--oneview-server-template`| OneView server template to use for blade provisioning, see OneView Server Template for setup.
-| `--oneview-os-plans`       | Comma separated list of OneView ICsp OS Build plans to use for OS provisioning. Note, this usto be --oneview-os-plan, which is no longer available.
+| `--oneview-os-plans`       | Comma separated list of OneView ICsp OS Build plans to use for OS provisioning. Note, this used to be --oneview-os-plan, which is no longer available.
 |                            |
 | `--oneview-ilo-user`       | ILO user id that is used during ICsp server creation
 | `--oneview-ilo-password`   | ILO password that is used durring ICsp server creation

--- a/docs/oneview.md
+++ b/docs/oneview.md
@@ -30,7 +30,7 @@ Infrastructure](http://h20195.www2.hp.com/V2/GetDocument.aspx?docname=4AA6-2595E
 Provisioning an operating system onto the allocated hardware that this driver will create requires us to have a working Insight Control server provisioning (ICsp) OS build plan (OSbp) created.  In addition the ICsp server should have dhcpv4 setup so that public interfaces for the server receive a routable ip address at startup.
 
 1. Use one of the standard RedHat Linux 7.1 boot images located under OS Build Plans (ProLiant OS - RHEL 7.1 x64 Scripted Install).
-2. Choose the action to save a new OS build plan.  The boot image can be named anything, but this driver will use RHEL71_DOCKER_1.8 for the default.  If you want an alternate name, please make sure to pass the --oneview-os-plan option with the alternate name.
+2. Choose the action to save a new OS build plan.  The boot image can be named anything, but this driver will use RHEL71_DOCKER_1.8 for the default.  If you want an alternate name, please make sure to pass the --oneview-os-plan option with the alternate name.  A list of build plans can be specified by using a comma to seperate the list.  Each build plan will be executed in succession.
 3. On the build plan (step 25) add a bash script step to the next to the last step that is waiting on the server to boot.  The script contents for this step should appear as the following:
    get script from : ```drivers/oneview/scripts/docker_os_build_plan.sh```
 You can choose to name the build step docker_os_build_prereq or anything that applies for your setup.  The purpose for this script is to prepare the environment with basic user configuration and networking startup.  The script should avoid fully provisioning docker, as this is managed by upstream docker contributions to the docker-machine project.
@@ -126,10 +126,10 @@ Environment variables and default values:
 | `--oneview-ssh-port`       | OneView build plan ssh host port
 |                            |
 | `--oneview-server-template`| OneView server template to use for blade provisioning, see OneView Server Template for setup.
-| `--oneview-os-plan`        | OneView ICSP OS Build plan to use for OS provisioning, see ICS OS Plan for setup.
+| `--oneview-os-plans`       | Comma separated list of OneView ICsp OS Build plans to use for OS provisioning. Note, this usto be --oneview-os-plan, which is no longer available.
 |                            |
-| `--oneview-ilo-user`       | ILO user id that is used during ICSP server creation
-| `--oneview-ilo-password`   | ILO password that is used durring ICSP server creation
+| `--oneview-ilo-user`       | ILO user id that is used during ICsp server creation
+| `--oneview-ilo-password`   | ILO password that is used durring ICsp server creation
 | `--oneview-ilo-port`       | Optional ILO port to use, defaults to 443
 
 

--- a/oneview/oneview_test.go
+++ b/oneview/oneview_test.go
@@ -3,6 +3,7 @@ package oneview
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/HewlettPackard/oneview-golang/icsp"
@@ -117,12 +118,13 @@ func TestCreateMachine(t *testing.T) {
 // TestCustomizeServer - simulate second part of create
 func TestCustomizeServer(t *testing.T) {
 	var (
-		err                                                 error
-		driver                                              Driver
-		d                                                   *OneViewTest
-		c                                                   *ov.OVClient
-		ic                                                  *icsp.ICSPClient
-		serialNumber, osbuildplan, hostname, user, pass, ip string
+		err                                    error
+		driver                                 Driver
+		d                                      *OneViewTest
+		c                                      *ov.OVClient
+		ic                                     *icsp.ICSPClient
+		serialNumber, hostname, user, pass, ip string
+		osbuildplans                           []string
 	)
 	if os.Getenv("ONEVIEW_TEST_ACCEPTANCE") != "true" {
 		return
@@ -149,7 +151,7 @@ func TestCustomizeServer(t *testing.T) {
 		assert.NoError(t, err, "getBlade threw error -> %s\n", err)
 		serialNumber = driver.Profile.SerialNumber.String()
 
-		osbuildplan = d.Tc.GetTestData(d.Env, "OSBuildPlan").(string)
+		osbuildplans = strings.Split(d.Tc.GetTestData(d.Env, "OSBuildPlans").(string), ",")
 
 		var sp *icsp.CustomServerAttributes
 		sp = sp.New()
@@ -176,8 +178,8 @@ func TestCustomizeServer(t *testing.T) {
 			IloPassword:      pass,
 			IloIPAddress:     ip,
 			IloPort:          443,
-			OSBuildPlan:      osbuildplan, // name of the OS build plan
-			PublicSlotID:     1,           // this is the slot id of the public interface
+			OSBuildPlans:     osbuildplans, // name of the OS build plan
+			PublicSlotID:     1,            // this is the slot id of the public interface
 			ServerProperties: sp,
 		}
 		// create d.Server and apply a build plan and configure the custom attributes

--- a/test/data/config_EGSL.json
+++ b/test/data/config_EGSL.json
@@ -47,7 +47,7 @@
         "ServerProfileName": "Server_Profile_scs79",
         "HardwareTypeURI": "/rest/server-hardware-types/DB7726F7-F601-4EA8-B4A6-D1EE1B32C07C",
         "GroupURI": "/rest/enclosure-groups/56ad0069-8362-42fd-b4e3-f5c5a69af039",
-        "OSBuildPlan":"RHEL71_DOCKER_1.8_Wenlock"
+        "OSBuildPlans":"RHEL71_DOCKER_1.8_Wenlock"
       },
       "expects_data": {
         "MACAddress": "34:64:A9:BB:E6:98",

--- a/test/data/config_EGSL_houston120.json
+++ b/test/data/config_EGSL_houston120.json
@@ -47,7 +47,7 @@
         "ServerProfileName": "docker_machine_test01",
         "HardwareTypeURI": "/rest/server-hardware-types/486B9A87-FCEB-4E9E-9E50-B0F54FAA0903",
         "GroupURI": "/rest/enclosure-groups/120eb19a-2447-4d26-a779-52bb009ff594",
-        "OSBuildPlan":"RHEL71_DOCKER_1.8"
+        "OSBuildPlans":"RHEL71_DOCKER_1.8"
       },
       "expects_data": {
         "IloIPAddress":  "16.85.0.55",

--- a/test/data/config_EGSL_houston200.json
+++ b/test/data/config_EGSL_houston200.json
@@ -49,7 +49,7 @@
         "ServerProfileName": "houegsl-c7000-04-04",
         "HardwareTypeURI": "/rest/server-hardware-types/1A1EBD9A-6ABE-4D96-BB9C-E9F39876BD3E",
         "GroupURI": "/rest/enclosure-groups/9bf6f6b2-abf5-4875-b72c-4cb6e744691b",
-        "OSBuildPlan":"RHEL71_DOCKER_1.8"
+        "OSBuildPlans":"RHEL71_DOCKER_1.8"
       },
       "expects_data": {
         "IloIPAddress":  "16.85.0.34",

--- a/test/data/config_EGSL_tb200.json
+++ b/test/data/config_EGSL_tb200.json
@@ -52,7 +52,7 @@
         "ServerProfileName": "wenlock-machine-1",
         "HardwareTypeURI": "/rest/server-hardware-types/486B9A87-FCEB-4E9E-9E50-B0F54FAA0903",
         "GroupURI": "/rest/enclosure-groups/e0ee00e0-38bc-47e3-a4fe-bf6d13ce4cd2",
-        "OSBuildPlan":"DiDC CentOS 7.1 x64 + Docker"
+        "OSBuildPlans":"DiDC CentOS 7.1 x64 + Docker"
       },
       "expects_data": {
         "MACAddress": "AA:43:83:10:00:BA",


### PR DESCRIPTION
We now support specifying a comma seperated list of build plans with the
--oneview-os-plans option.  This option replaces --oneview-os-plan,
which is also no longer available.

Update docs, test and wait for the following PR to merge before merging
this one:

https://github.com/HewlettPackard/oneview-golang/pull/73