### PR TITLE
Adding api version options

### DIFF
--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -14,7 +14,8 @@ craete an environment, `drivers/oneview/.oneview.env`, script to export these va
 
 ```bash
 cat > "$(git rev-parse --show-toplevel)/drivers/oneview/.oneview.env" << ONEVIEW
-ONEVIEW_APIVERSION=120
+ONEVIEW_OV_APIVERSION=201
+ONEVIEW_ICSP_APIVERSION=200
 
 ONEVIEW_ILO_USER=docker
 ONEVIEW_ILO_PASSWORD=password
@@ -122,7 +123,7 @@ Sometimes we want to make edits to the oneview-golang source before making any c
 to our current project.  This enables us to do end-to-end hacking on the golang
 sdk for oneview as well as the plugin for docker-machine.
 
-1. First make sure that the source for oneview-golang is checkout out relative to 
+1. First make sure that the source for oneview-golang is checkout out relative to
    the source for this project.  Example:  ../oneview-golang
 
 2. Use the following command to build the source for the plugin:

--- a/docs/oneview.md
+++ b/docs/oneview.md
@@ -114,11 +114,13 @@ Environment variables and default values:
 | `--oneview-ov-password`    | String Password to OneView
 | `--oneview-ov-domain`      | String Domain to OneView
 | `--oneview-ov-endpoint`    | String url end point, base path
+| `--oneview-ov-apiversion`  | Force api version to an older release, ie; 201
 |                            |
 | `--oneview-icsp-user`      | String User to ICSP
 | `--oneview-icsp-password`  | String Password to ICSP
 | `--oneview-icsp-domain`    | String Domain to ICSP
 | `--oneview-icsp-endpoint`  | String url end point, base path
+| `--oneview-icsp-apiversion`| Force api version to an older release, ie; 200
 |                            |
 | `--oneview-sslverify`      | Bool false means no https verification
 |                            |

--- a/oneview/oneview.go
+++ b/oneview/oneview.go
@@ -89,6 +89,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Value:  "",
 			EnvVar: "ONEVIEW_OV_ENDPOINT",
 		},
+		mcnflag.IntFlag{
+			Name:   "oneview-ov-apiversion",
+			Usage:  "Force api version to an older release, ie; 201",
+			Value:  1,
+			EnvVar: "ONEVIEW_OV_APIVERSION",
+		},
 		mcnflag.StringFlag{
 			Name:   "oneview-icsp-user",
 			Usage:  "User Name to OneView Insight Controller",
@@ -112,6 +118,12 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 			Usage:  "OneView Insight Controller URL Endpoint",
 			Value:  "",
 			EnvVar: "ONEVIEW_ICSP_ENDPOINT",
+		},
+		mcnflag.IntFlag{
+			Name:   "oneview-icsp-apiversion",
+			Usage:  "Force api version to an older release, ie; 200",
+			Value:  1,
+			EnvVar: "ONEVIEW_ICSP_APIVERSION",
 		},
 		mcnflag.BoolFlag{
 			Name:   "oneview-sslverify",
@@ -202,17 +214,22 @@ func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
 		flags.String("oneview-icsp-domain"),
 		flags.String("oneview-icsp-endpoint"),
 		flags.Bool("oneview-sslverify"),
-		1)
+		flags.Int("oneview-icsp-apiversion"))
 
 	d.ClientOV = d.ClientOV.NewOVClient(flags.String("oneview-ov-user"),
 		flags.String("oneview-ov-password"),
 		flags.String("oneview-ov-domain"),
 		flags.String("oneview-ov-endpoint"),
 		flags.Bool("oneview-sslverify"),
-		1)
+		flags.Int("oneview-ov-apiversion"))
 
-	d.ClientICSP.RefreshVersion()
-	d.ClientOV.RefreshVersion()
+	// we only get the version from /version if it's not setup becuse 1 is not a real version
+	if flags.Int("oneview-icsp-apiversion") == 1 {
+		d.ClientICSP.RefreshVersion()
+	}
+	if flags.Int("oneview-ov-apiversion") == 1 {
+		d.ClientOV.RefreshVersion()
+	}
 
 	d.IloUser = flags.String("oneview-ilo-user")
 	d.IloPassword = flags.String("oneview-ilo-password")


### PR DESCRIPTION
We need to be able to set the api version
to an older version for testing on newer apliances

Signed-off-by: Edward Raigosa <edward.raigosa@hpe.com>